### PR TITLE
Pin boost to 1.70

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   patches:
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
@@ -28,13 +28,13 @@ requirements:
     - python
     - catkin_pkg
     - console_bridge
-    - boost-cpp 1.68.*
+    - boost-cpp 1.70.*
     - ros-catkin
   run:
     - ros-conda-mutex * melodic
     - ros-conda-base
     - console_bridge
-    - boost-cpp 1.68.*
+    - boost-cpp 1.70.*
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,7 @@ requirements:
   run:
     - ros-conda-mutex * melodic
     - ros-conda-base
+    - python
     - console_bridge
     - boost-cpp 1.70.*
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

As discussed in https://gitter.im/RoboStack/Lobby, this should allow execution of the following command, which currently fails: 
```conda create --name ros --channel conda-forge ros-cpp-common boost```

In particular, `ros-conda-base` and `ros-cpp-common` have incompatible version pinnings of boost, i.e. `1.70.*` and `1.68.*` respectively (see https://github.com/conda-forge/ros-conda-base-feedstock/blob/master/recipe/meta.yaml for `ros-conda-base`):
```
Package boost-cpp conflicts for:
boost==1.68.0 -> boost-cpp=1.68.0
ros-core -> ros-ros -> boost-cpp[version='>=1.70.0,<1.70.1.0a0']
ros-core -> ros-class-loader -> boost-cpp[version='>=1.70.0,<1.70.1.0a0']
```

@wolfv mentioned that "conda-forge has a pinning to 1.70"

Therefore, the pinning here is changed from 1.68.* to 1.70.*